### PR TITLE
prompt fallback implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ gcloud functions deploy pr-regression-review \
   --no-allow-unauthenticated \
   --memory=512MB \
   --timeout=300s \
-  --set-env-vars="GCS_BUCKET=rawl9001,AZURE_DEVOPS_ORG=batdigital,AZURE_DEVOPS_PROJECT=Consumer%20Platforms,AZURE_DEVOPS_REPO=AEM-Platform-Core,VERTEX_LOCATION=global,VERTEX_PROJECT=cog01k6msqf1e7e5z9m5grb69qmrm,GEMINI_MODEL=gemini-3-pro-preview" \
+  --set-env-vars="GCS_BUCKET=rawl9001bat,AZURE_DEVOPS_ORG=batdigital,AZURE_DEVOPS_PROJECT=Consumer%20Platforms,AZURE_DEVOPS_REPO=AEM-Platform-Core,VERTEX_LOCATION=global,VERTEX_PROJECT=cog01k6msqf1e7e5z9m5grb69qmrm,GEMINI_MODEL=gemini-3-pro-preview" \
   --set-secrets="AZURE_DEVOPS_PAT=azure-devops-pat:latest"
 
 # After deployment, grant invoker permission to authorized service accounts

--- a/pr_review/gemini.py
+++ b/pr_review/gemini.py
@@ -5,7 +5,7 @@ import time
 
 from google import genai
 
-from pr_review.prompt import SYSTEM_PROMPT
+from pr_review.prompt import load_system_prompt
 from pr_review.utils import timed_operation
 
 logger = logging.getLogger("pr_review")
@@ -17,9 +17,12 @@ def call_gemini(config: dict, prompt: str) -> str:
     model_name = config["GEMINI_MODEL"]
     project = config["VERTEX_PROJECT"]
     location = config["VERTEX_LOCATION"]
+    
+    # Load system prompt from GCS or fallback to hardcoded
+    system_prompt = load_system_prompt(config["GCS_BUCKET"])
 
     logger.info(f"[GEMINI] Calling Vertex AI | Model: {model_name} | Project: {project} | Location: {location}")
-    logger.info(f"[GEMINI] Prompt size: {len(prompt)} chars | System prompt: {len(SYSTEM_PROMPT)} chars")
+    logger.info(f"[GEMINI] Prompt size: {len(prompt)} chars | System prompt: {len(system_prompt)} chars")
     logger.debug(f"[GEMINI] Config: max_output_tokens=8192, temperature=0.2")
 
     with timed_operation() as elapsed:
@@ -39,7 +42,7 @@ def call_gemini(config: dict, prompt: str) -> str:
                 model=model_name,
                 contents=prompt,
                 config={
-                    "system_instruction": SYSTEM_PROMPT,
+                    "system_instruction": system_prompt,
                     "max_output_tokens": 8192,
                     "temperature": 0.2,  # Lower for more focused analysis
                 },

--- a/pr_review/prompt.py
+++ b/pr_review/prompt.py
@@ -1,6 +1,18 @@
 """Gemini review prompt construction."""
 
 import difflib
+import logging
+import os
+
+from google.cloud import storage
+from google.cloud.exceptions import NotFound
+
+from pr_review.utils import timed_operation
+
+logger = logging.getLogger("pr_review")
+
+# Default GCS path for system prompt blob
+DEFAULT_SYSTEM_PROMPT_BLOB_PATH = "prompts/system-prompt.txt"
 
 SYSTEM_PROMPT = """You are a supportive senior AEM frontend developer helping your team ship quality code with confidence. You are also a senior QA engineer and accessibility expert. Your role is to identify potential regressions early so the team can address them before merge.
 
@@ -121,6 +133,40 @@ The main objective is to provide clear impact analysis of changes on the existin
 
 When the PR is solid overall, acknowledge the author's effort. These findings are meant to support the team's success, not create obstacles.
 """
+
+
+def load_system_prompt(bucket_name: str) -> str:
+    """Load system prompt from GCS or fall back to hardcoded constant.
+    
+    Args:
+        bucket_name: GCS bucket name to load prompt from
+        
+    Returns:
+        System prompt text
+    """
+    blob_path = os.environ.get("SYSTEM_PROMPT_BLOB_PATH", DEFAULT_SYSTEM_PROMPT_BLOB_PATH)
+    
+    with timed_operation() as elapsed:
+        try:
+            # Attempt to load from GCS
+            logger.info(f"[PROMPT] Loading system prompt from GCS | Bucket: {bucket_name} | Path: {blob_path}")
+            
+            storage_client = storage.Client()
+            bucket = storage_client.bucket(bucket_name)
+            blob = bucket.blob(blob_path)
+            
+            prompt_text = blob.download_as_text()
+            
+            logger.info(f"[PROMPT] Loaded from GCS | {len(prompt_text)} chars | {elapsed():.0f}ms")
+            return prompt_text
+            
+        except NotFound:
+            logger.warning(f"[PROMPT] Blob not found in GCS, using fallback | Path: {blob_path} | {elapsed():.0f}ms")
+            return SYSTEM_PROMPT
+            
+        except Exception as e:
+            logger.error(f"[PROMPT] Failed to load from GCS, using fallback | Error: {type(e).__name__}: {str(e)} | {elapsed():.0f}ms")
+            return SYSTEM_PROMPT
 
 
 def _generate_unified_diff(old_content, new_content, path, context_lines=5):

--- a/prompts/system-prompt.txt
+++ b/prompts/system-prompt.txt
@@ -14,12 +14,23 @@ Your expertise covers:
 - Unchanged context lines are provided only to help you understand the change.
 - If a change *might* affect other code, flag it as "Worth Verifying" — do not go searching for impacts yourself.
 
-## Review Focus: Regression Analysis
+## Guidelines
 
-Analyze changes for potential regressions: removed/renamed AEM dialogs or functions that other code depends on, modified behavior in existing logic, breaking changes to data-attributes/CSS classes/JS interfaces, altered HTL contracts (Sling Model properties, template parameters), CSS class removals or specificity changes, and HTML structure modifications affecting JavaScript or accessibility.
+- Be specific about file paths and line references
+- Prioritize findings by potential impact, not code style
+- If no significant concerns are found, acknowledge the solid work
+- Focus only on concrete concerns observed in the diff section "Unified Diff" 
+- Keep feedback clear and actionable
+
+## Code Review Principles
+
+- **VERY IMPORTANT**: Analyze changes for potential regressions: removed/renamed AEM dialogs or functions that other code depends on, modified behavior in existing logic, breaking changes to data-attributes/CSS classes/JS interfaces, altered HTL contracts (Sling Model properties, template parameters), CSS class removals or specificity changes, and HTML structure modifications affecting JavaScript or accessibility.
++ Follow the following categories: 
+  - **Requires Attention Before Merge** (action-required): Security vulnerabilities, breaking changes, data loss risks, or production-impacting bugs that need resolution before merge. Each item should explain what changed and what to verify.
+  - **Worth Verifying** (review-recommended): Code quality considerations, performance concerns, potential edge cases, or changes benefiting from extra testing. Include the change in question, potential impact, and suggested verification steps.
+  - **Low Concern** (note): Minor observations, suggestions for future consideration, or context that may be helpful — changes unlikely to cause issues but worth noting for awareness.
 
 ## Output Format
-
 Generate a markdown review report with these sections:
 
 # PR Review: {PR Title}
@@ -29,23 +40,16 @@ Generate a markdown review report with these sections:
 ## Summary
 Brief description of what this PR changes (2-3 sentences).
 
-## Impact Assessment
+## What's Working Well
+Acknowledge positive patterns, good practices, or thoughtful implementations observed in the PR. If the changes are solid, say so.
 
-### ⚠️ Requires Attention Before Merge
-Security vulnerabilities, breaking changes, data loss risks, or production-impacting bugs that need resolution before merge. Each item should explain what changed, what to verify, and who should be consulted.
-
-### 👀 Worth Verifying
-Code quality considerations, performance concerns, potential edge cases, or changes benefiting from extra testing. Include the change in question, potential impact, and suggested verification steps.
-
-### ✅ Low Concern
-Minor observations, suggestions for future consideration, or context that may be helpful — changes unlikely to cause issues but worth noting for awareness.
-
-## Recommended Test Coverage
-Specific test scenarios that should be validated before merge (focus on accessibility and regression testing):
-Add status checkbox to check when the issue is tested
-1. {scenario with expected behavior}
-2. {scenario with expected behavior}
-...
+## Impact Assessment Summary
++ Present identified issues in a summary table with the columns:
+- Code Snippet
+- Issue
+- Recommended Solution
+- Priority: action-required | review-recommended | note
++ If no issues are found, briefly state that the code meets best practices
 
 ## Detailed Findings
 
@@ -55,17 +59,8 @@ For each significant finding, use this format:
 
 **Priority:** action-required | review-recommended | note
 **Applies to:** {file path}
-**Category:** security | aem | frontend | testing
+**Category:** security | aem | frontend | testing | accessibility
 
 {Explanation of the finding in plain sentences, including impact and reasoning so everyone understands the tradeoffs. Include suggested verification steps or recommended approach.}
 
----
 
-## Guidelines
-
-- Be specific about file paths and line references
-- Prioritize findings by potential impact, not code style
-- If no significant concerns are found, acknowledge the solid work
-- Keep the report under 200 lines total
-- Focus only on concrete concerns observed in the diff
-- Keep feedback clear and actionable


### PR DESCRIPTION
- Add load_system_prompt(bucket_name) in pr_review/prompt.py to fetch
  prompt from GCS (SYSTEM_PROMPT_BLOB_PATH, default prompts/system-prompt.txt)
  and fall back to hardcoded SYSTEM_PROMPT on NotFound or other errors
- Use timed_operation and structured logging for source and timing
- Update pr_review/gemini.py to call load_system_prompt(config[GCS_BUCKET])
  instead of importing SYSTEM_PROMPT; use returned value for API and logging
