### PR TITLE
feat: add debug flag to save prompt input to GCS

### DIFF
--- a/api/api-spec.yaml
+++ b/api/api-spec.yaml
@@ -10,6 +10,26 @@ paths:
     post:
       summary: Webhook receiver for PR review
       operationId: receiveWebhook
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            required:
+              - pr_id
+              - commit_sha
+            properties:
+              pr_id:
+                type: integer
+                description: Pull request ID
+              commit_sha:
+                type: string
+                description: Commit SHA
+              debug:
+                type: boolean
+                description: Enable debug mode to save prompt inputs to GCS
+                default: false
       responses:
         "202":
           description: Accepted for processing
@@ -28,6 +48,22 @@ paths:
     post:
       summary: Review Pull Request
       operationId: reviewPR
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            required:
+              - pr_id
+            properties:
+              pr_id:
+                type: integer
+                description: Pull request ID
+              debug:
+                type: boolean
+                description: Enable debug mode to save prompt inputs to GCS
+                default: false
       responses:
         "200":
           description: Review completed successfully

--- a/pr_review/entry_points.py
+++ b/pr_review/entry_points.py
@@ -36,7 +36,7 @@ def review_pr(request):
         Cloud Run before this function is invoked.
 
     Request:
-        POST with JSON body: {"pr_id": 12345}
+        POST with JSON body: {"pr_id": 12345, "debug": false}
         Header: Authorization: Bearer <google-identity-token>
 
     Response:
@@ -73,7 +73,8 @@ def review_pr(request):
                 return make_response({"error": "Missing required field: pr_id"}, 400)
 
             pr_id = int(pr_id)
-            logger.info(f"[REQUEST] Processing PR #{pr_id}")
+            debug = request_json.get("debug", False)
+            logger.info(f"[REQUEST] Processing PR #{pr_id} | Debug: {debug}")
         except (ValueError, TypeError) as e:
             logger.error(f"[REQUEST] Invalid pr_id format: {e}")
             return make_response({"error": f"Invalid pr_id: {e}"}, 400)
@@ -118,7 +119,7 @@ def review_pr(request):
 
             # Process the review using shared logic
             logger.info(f"[FLOW] Step 3/3: Processing review")
-            result = process_pr_review(config, ado, pr_id, pr, file_diffs)
+            result = process_pr_review(config, ado, pr_id, pr, file_diffs, debug=debug)
 
             logger.info(f"[COMPLETE] PR #{pr_id} review finished | Severity: {result.max_severity} | Action: {result.action_taken or 'none'} | Total time: {elapsed():.0f}ms")
             logger.info("=" * 60)
@@ -161,7 +162,8 @@ def review_pr_pubsub(cloud_event: CloudEvent) -> None:
             "pr_id": 12345,
             "commit_sha": "abc123def...",  // Optional: provided by webhook receiver
             "received_at": "2026-01-03T10:30:00Z",
-            "source": "azure-devops-pipeline"
+            "source": "azure-devops-pipeline",
+            "debug": false  // Optional: enable prompt input debugging
         }
 
     The function will:
@@ -202,10 +204,12 @@ def review_pr_pubsub(cloud_event: CloudEvent) -> None:
 
             # Extract commit_sha from message (provided by webhook receiver)
             message_commit_sha = message.get("commit_sha")
+            debug = message.get("debug", False)
+
             if message_commit_sha:
-                logger.info(f"[PUBSUB] Processing PR #{pr_id} @ {message_commit_sha[:8]} (from message)")
+                logger.info(f"[PUBSUB] Processing PR #{pr_id} @ {message_commit_sha[:8]} (from message) | Debug: {debug}")
             else:
-                logger.info(f"[PUBSUB] Processing PR #{pr_id} (commit_sha will be fetched from ADO)")
+                logger.info(f"[PUBSUB] Processing PR #{pr_id} (commit_sha will be fetched from ADO) | Debug: {debug}")
 
         except (ValueError, TypeError, json.JSONDecodeError) as e:
             logger.error(f"[PUBSUB] Failed to parse message: {e}")
@@ -267,7 +271,7 @@ def review_pr_pubsub(cloud_event: CloudEvent) -> None:
 
             # Process the review using shared logic
             logger.info(f"[FLOW] Step 4/4: Processing review")
-            result = process_pr_review(config, ado, pr_id, pr, file_diffs)
+            result = process_pr_review(config, ado, pr_id, pr, file_diffs, debug=debug)
 
             # Update idempotency marker with completion status
             update_marker_completed(bucket_name, pr_id, commit_sha, result.max_severity, result.commented)
@@ -591,7 +595,8 @@ def receive_webhook(request):
 
         {
             "pr_id": 357462,
-            "commit_sha": "abc123def456789..."
+            "commit_sha": "abc123def456789...",
+            "debug": false
         }
 
     Response (202 Accepted):
@@ -630,6 +635,7 @@ def receive_webhook(request):
         # Validate required fields
         pr_id = data.get("pr_id")
         commit_sha = data.get("commit_sha")
+        debug = data.get("debug", False)
 
         if not pr_id:
             logger.error("[PARSE] Missing pr_id in request")
@@ -650,14 +656,15 @@ def receive_webhook(request):
             logger.error(f"[PARSE] Invalid commit_sha: {commit_sha}")
             return {"error": "commit_sha must be a string of at least 7 characters"}, 400
 
-        logger.info(f"[WEBHOOK] PR #{pr_id} @ {commit_sha[:8]}")
+        logger.info(f"[WEBHOOK] PR #{pr_id} @ {commit_sha[:8]} | Debug: {debug}")
 
         # Build Pub/Sub message
         message = {
             "pr_id": pr_id,
             "commit_sha": commit_sha,
             "received_at": datetime.now(timezone.utc).isoformat(),
-            "source": "azure-devops-pipeline"
+            "source": "azure-devops-pipeline",
+            "debug": debug
         }
 
         # Publish to Pub/Sub

--- a/pr_review/gemini.py
+++ b/pr_review/gemini.py
@@ -11,15 +11,34 @@ from pr_review.utils import timed_operation
 logger = logging.getLogger("pr_review")
 
 
-def call_gemini(config: dict, prompt: str) -> str:
-    """Send prompt to Gemini via Vertex AI and return response."""
+def call_gemini(config: dict, prompt: str, debug: bool = False, pr_id: int = None) -> str:
+    """Send prompt to Gemini via Vertex AI and return response.
+
+    Args:
+        config: Configuration dictionary
+        prompt: User prompt to send to Gemini
+        debug: If True, save prompt inputs to GCS
+        pr_id: Pull request ID (required when debug=True)
+
+    Returns:
+        Response text from Gemini
+    """
 
     model_name = config["GEMINI_MODEL"]
     project = config["VERTEX_PROJECT"]
     location = config["VERTEX_LOCATION"]
-    
+
     # Load system prompt from GCS or fallback to hardcoded
     system_prompt = load_system_prompt(config["GCS_BUCKET"])
+
+    # Save prompt inputs if debug mode is enabled
+    if debug and pr_id:
+        try:
+            from pr_review.storage import save_prompt_input
+            save_prompt_input(config["GCS_BUCKET"], pr_id, system_prompt, prompt)
+            logger.info(f"[GEMINI] Debug mode: Prompt input saved to GCS for PR #{pr_id}")
+        except Exception as e:
+            logger.warning(f"[GEMINI] Failed to save prompt input (non-blocking): {e}")
 
     logger.info(f"[GEMINI] Calling Vertex AI | Model: {model_name} | Project: {project} | Location: {location}")
     logger.info(f"[GEMINI] Prompt size: {len(prompt)} chars | System prompt: {len(system_prompt)} chars")

--- a/pr_review/review.py
+++ b/pr_review/review.py
@@ -16,6 +16,7 @@ def process_pr_review(
     pr_id: int,
     pr: dict,
     file_diffs: list,
+    debug: bool = False,
 ) -> ReviewResult:
     """
     Core PR review logic shared by HTTP and Pub/Sub entry points.
@@ -33,6 +34,7 @@ def process_pr_review(
         pr_id: Pull Request ID
         pr: PR metadata dict from Azure DevOps
         file_diffs: List of file diff dicts
+        debug: If True, save prompt inputs to GCS
 
     Returns:
         ReviewResult with all review details and actions taken
@@ -54,7 +56,7 @@ def process_pr_review(
     prompt = build_review_prompt(pr, file_diffs)
     logger.info(f"[REVIEW] Prompt built: {len(prompt)} chars")
 
-    review = gemini.call_gemini(config, prompt)
+    review = gemini.call_gemini(config, prompt, debug=debug, pr_id=pr_id)
 
     # Determine severity
     logger.info("[REVIEW] Analyzing severity")

--- a/pr_review/storage.py
+++ b/pr_review/storage.py
@@ -46,3 +46,52 @@ def save_to_storage(bucket_name: str, pr_id: int, review: str) -> str:
         except Exception as e:
             logger.error(f"[GCS] Upload FAILED | {elapsed():.0f}ms | Error: {str(e)}")
             raise
+
+
+def save_prompt_input(bucket_name: str, pr_id: int, system_prompt: str, user_prompt: str) -> str:
+    """Save prompt input to Cloud Storage for debugging.
+
+    Args:
+        bucket_name: GCS bucket name
+        pr_id: Pull request ID
+        system_prompt: System instruction/prompt
+        user_prompt: User prompt content
+
+    Returns:
+        Full GCS path (gs://bucket/path)
+    """
+    logger.info(f"[GCS] Saving prompt input for PR #{pr_id} to bucket: {bucket_name}")
+    logger.debug(f"[GCS] System prompt size: {len(system_prompt)} chars, User prompt size: {len(user_prompt)} chars")
+
+    with timed_operation() as elapsed:
+        try:
+            client = storage.Client()
+            bucket = client.bucket(bucket_name)
+
+            # Date partitioning: yyyy/mm/dd (same as review)
+            now = datetime.now(timezone.utc)
+            date_path = now.strftime("%Y/%m/%d")
+            timestamp = now.strftime("%H%M%S")
+
+            blob_path = f"reviews/{date_path}/pr-{pr_id}-{timestamp}-prompt-input.txt"
+            blob = bucket.blob(blob_path)
+
+            # Combine system and user prompts with clear separation
+            combined_content = f"""=== SYSTEM PROMPT ===
+
+{system_prompt}
+
+=== USER PROMPT ===
+
+{user_prompt}
+"""
+
+            blob.upload_from_string(combined_content, content_type="text/plain")
+
+            full_path = f"gs://{bucket_name}/{blob_path}"
+            logger.info(f"[GCS] Prompt input saved: {blob_path} | {len(combined_content)} bytes | {elapsed():.0f}ms")
+
+            return full_path
+        except Exception as e:
+            logger.error(f"[GCS] Prompt input save FAILED | {elapsed():.0f}ms | Error: {str(e)}")
+            raise


### PR DESCRIPTION
- Added save_prompt_input() function to storage.py for saving prompts

- Updated call_gemini() to accept debug parameter and save prompts when enabled

- Updated process_pr_review() to accept and pass debug flag

- Updated all entry points (HTTP, Pub/Sub, webhook) to accept debug parameter

- Updated API spec with debug parameter documentation

When debug=true, both system and user prompts are saved to GCS in the same bucket and date partitioning as review results with filename format: pr-{id}-{timestamp}-prompt-input.txt

Closes #21